### PR TITLE
MAINT update dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'dtcwt': ['data/*.npz',],
     },
 
-    install_requires=[ 'numpy<2.0.0', 'scipy', 'six', ],
+    install_requires=[ 'numpy<1.23', 'scipy', 'six', ],
 
     extras_require={
         'docs': [ 'sphinx', 'docutils', 'matplotlib', 'ipython', ],


### PR DESCRIPTION
- I couldn't run pytest on my machine, because `setup()` is removed in pytest 8.0: [https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose](url)
I have set the requirement to `pyteset<8, >=7`
But it would be better to use `setup_module()` instead of `setup()`
- `dtcwt` is incompable with `numpy>=1.23`