### PR TITLE
Use raw string in docs which have backslash

### DIFF
--- a/dtcwt/tf/lowlevel.py
+++ b/dtcwt/tf/lowlevel.py
@@ -205,7 +205,7 @@ def rowfilter(X, h, align=False):
 
 
 def coldfilt(X, ha, hb, no_decimate=False):
-    """
+    r"""
     Filter the columns of image X using the two filters ha and hb =
     reverse(ha).
 


### PR DESCRIPTION
## Description

Building docs complains about the backslash:
```
dtcwt/tf/lowlevel.py:208: SyntaxWarning: invalid escape sequence '\p'
```